### PR TITLE
Zoom-improved: prevent camera from going above 2500

### DIFF
--- a/Zoom-Improved/Program.cs
+++ b/Zoom-Improved/Program.cs
@@ -72,6 +72,8 @@ namespace ZoomImproved
 						zoomValue -= 50;
 					if (zoomValue < 1134)
 						zoomValue = 1134;
+					if (zoomValue > 2500)
+						zoomValue = 2500;
 					ZoomVar.SetValue(zoomValue);
 					Menu.Item("distance").SetValue(new Slider(zoomValue, 1134, 2500));
 					args.Process = false;


### PR DESCRIPTION
Zooming out too much causes crashing of Dota (even on my gtx 970).

Will prevent the user from zooming out past 2500.
